### PR TITLE
New delete button for find / findOne

### DIFF
--- a/client/views/pages/browse_collection/browse_collection.html
+++ b/client/views/pages/browse_collection/browse_collection.html
@@ -69,12 +69,19 @@
 
                         <div class="ibox-footer" id="divBrowseCollectionFooter" style="display: none;">
                             <div class="row">
-                                <div class="col-lg-12">
+                                <div class="col-lg-6">
                                     <button id="btnSaveFindFindOne"
                                             class="btn btn-block btn-outline btn-primary ladda-button"
                                             type="button"
                                             data-style="contract">
                                         <strong>Save</strong></button>
+                                </div>
+                                <div class="col-lg-6">
+                                    <button id="btnDelFindFindOne"
+                                            class="btn btn-block btn-outline btn-primary ladda-button"
+                                            type="button"
+                                            data-style="contract">
+                                        <strong>Delete</strong></button>
                                 </div>
                             </div>
                         </div>

--- a/client/views/pages/browse_collection/browse_collection.js
+++ b/client/views/pages/browse_collection/browse_collection.js
@@ -54,6 +54,11 @@ Template.browseCollection.events({
         Template.browseCollection.saveEditor();
     },
 
+    'click #btnDelFindFindOne': function (e) {
+        e.preventDefault();
+        Template.browseCollection.deleteDocument();
+    },
+
     'click #btnShowQueryHistories': function () {
         $('#queryHistoriesModal').modal('show');
     },
@@ -427,6 +432,56 @@ Template.browseCollection.saveEditor = function () {
                             if ((i++) == (convertedDocs.length - 1)) {
                                 // last time
                                 toastr.success('Successfully updated document(s)');
+                                Ladda.stopAll();
+                            }
+                        }
+                    });
+                }
+            });
+        }
+    });
+
+};
+
+
+Template.browseCollection.deleteDocument = function () {
+    var convertedDocs;
+    try {
+        convertedDocs = Template.convertAndCheckJSONAsArray(Template.browseCollection.getActiveEditorValue());
+    }
+    catch (e) {
+        toastr.error('Syntax error, can not save document(s): ' + e);
+        return;
+    }
+
+    swal({
+        title: "Are you sure ?",
+        text: convertedDocs.length + ' document(s) will be deleted,  are you sure ?',
+        type: "info",
+        showCancelButton: true,
+        confirmButtonColor: "#DD6B55",
+        confirmButtonText: "Yes!",
+        cancelButtonText: "No"
+    }, function (isConfirm) {
+        if (isConfirm) {
+
+            var l = Ladda.create(document.querySelector('#btnDelFindFindOne'));
+            l.start();
+
+            var selectedCollection = Session.get(Template.strSessionSelectedCollection);
+            var convertIds = $('#aConvertObjectIds').iCheck('update')[0].checked;
+            var convertDates = $('#aConvertIsoDates').iCheck('update')[0].checked;
+            var i = 0;
+            _.each(convertedDocs, function (doc) {
+                if (doc._id) {
+                    Meteor.call("delete", selectedCollection, {_id: doc._id}, convertIds, convertDates, function (err, result) {
+                        if (err || result.error) {
+                            Template.showMeteorFuncError(err, result, "Couldn't delete one of the documents");
+                            Ladda.stopAll();
+                        } else {
+                            if ((i++) == (convertedDocs.length - 1)) {
+                                // last time
+                                toastr.success('Successfully deleted document(s)');
                                 Ladda.stopAll();
                             }
                         }


### PR DESCRIPTION
Hello Sercan!

I have been working in 
https://github.com/rsercano/mongoclient/issues/119

It was quite easy, just an adaptation of the save functionality.

However maybe we could trigger a refresh right after the delete, so the document gets updated.
Also I think the delete on find can be very dangerous because you can easily delete everything in a collection.

Please let me know if you like it or how could we improve it.

Cheers!

Jaime
