### PR TITLE
Dockerfile cleanup and switch to ubuntu 16.04 instead of Debian

### DIFF
--- a/.docker/install-deps.sh
+++ b/.docker/install-deps.sh
@@ -6,7 +6,7 @@ printf "\n[-] Installing base OS dependencies...\n\n"
 
 apt-get update -y
 
-apt-get install -y --no-install-recommends curl ca-certificates bzip2 build-essential numactl python git wget
+apt-get install -y --no-install-recommends curl ca-certificates bzip2 build-essential numactl python git wget libc6
 
 dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
 

--- a/.docker/install-mongo.sh
+++ b/.docker/install-mongo.sh
@@ -8,9 +8,9 @@ fi
 
   printf "\n[-] Installing MongoDB ${MONGO_VERSION}...\n\n"
 
-	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-	
-	echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/$MONGO_MAJOR multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org.list
+	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv BC711F9BA15703C6
+
+	echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/$MONGO_MAJOR multiverse" | tee /etc/apt/sources.list.d/mongodb-org.list
 
 	apt-get update
 

--- a/.docker/install-mongo.sh
+++ b/.docker/install-mongo.sh
@@ -8,9 +8,9 @@ fi
 
   printf "\n[-] Installing MongoDB ${MONGO_VERSION}...\n\n"
 
-	apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0C49F3730359A14518585931BC711F9BA15703C6
-
-  echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
+	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+	
+	echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/$MONGO_MAJOR multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org.list
 
 	apt-get update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian
 MAINTAINER R.Sercan Özdemir <info@mongoclient.com>
 
 RUN groupadd -r node && useradd -m -g node node

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,16 @@ ENV BUILD_SCRIPTS_DIR /opt/build_scripts
 COPY .docker $BUILD_SCRIPTS_DIR
 RUN chmod -R 770 $BUILD_SCRIPTS_DIR
 
-# copy the app to the container
-COPY . $APP_SOURCE_DIR
-
 # install base dependencies, build app, cleanup
 RUN cd $BUILD_SCRIPTS_DIR && \
 		bash $BUILD_SCRIPTS_DIR/install-deps.sh && \
 		bash $BUILD_SCRIPTS_DIR/install-node.sh && \
 		bash $BUILD_SCRIPTS_DIR/install-mongo.sh && \
 		bash $BUILD_SCRIPTS_DIR/post-install-cleanup.sh
+
+# copy the app to the container
+COPY . $APP_SOURCE_DIR
+RUN chmod -R 770 $BUILD_SCRIPTS_DIR
 
 # install Meteor, build app, clean up
 RUN cd $APP_SOURCE_DIR && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM ubuntu:16.04
 MAINTAINER R.Sercan Özdemir <info@mongoclient.com>
 
 RUN groupadd -r node && useradd -m -g node node


### PR DESCRIPTION
I had some issues with the shell feature and the latest mongo version as that mongoclient requires a newer version of glibc than is shipped with Debian Jessie.

I updated the Dockerfile and associated code to use Ubuntu 16.04 as base image instead, as that was a lot easier than updating the glibc included in Debian.

I also just rearranged some commands in the Dockerfile to take a better advantage of caching.

If you don't want to switch to ubuntu as base image, you can just decline this pull request, but it seems to work fine for me and the shell works as opposed to complaining about glibc :)