### PR TITLE
Add query result representation in grid view

### DIFF
--- a/client/imports/modules/ui_components/index.js
+++ b/client/imports/modules/ui_components/index.js
@@ -169,13 +169,7 @@ UIComponents.prototype = {
 
     setGridEditorValue({ selector, value }) {
       // collect all keys
-      const allKeys = new Set();
-      value.forEach((row) => {
-        Object.keys(row).forEach(k => allKeys.add(k));
-      });
-      if (allKeys.size === 0) {
-        allKeys.add('(empty)');
-      }
+      const allKeys = this._collectAllKeys(value);
       // create HTML table
       let html = '<table class="table table-bordered">';
       // table headers
@@ -193,6 +187,7 @@ UIComponents.prototype = {
 
       const container = $(`#${selector}`);
       container.html(html);
+
       const table = container.find('table');
       table.DataTable({
         paging: false
@@ -203,10 +198,22 @@ UIComponents.prototype = {
       });
     },
 
+    _collectAllKeys(value) {
+      const allKeys = new Set();
+      value.forEach((row) => {
+        Object.keys(row).forEach(k => allKeys.add(k));
+      });
+      if (allKeys.size === 0) {
+        allKeys.add('(empty)');
+      }
+      return allKeys;
+    },
+
     _objectToGridRow(obj, allKeys) {
       let html = '<tr>';
       allKeys.forEach((key) => {
-        let val = obj.hasOwnProperty(key) ? obj[key] : '';
+        let val = obj[key];
+        if (typeof val === 'undefined') val = '';
         if (val !== null && typeof val === 'object') {
           const valKeys = Object.keys(val);
           if (valKeys.length === 1 && valKeys[0] === '$date') {

--- a/client/imports/modules/ui_components/index.js
+++ b/client/imports/modules/ui_components/index.js
@@ -168,6 +168,7 @@ UIComponents.prototype = {
     },
 
     setGridEditorValue({ selector, value }) {
+      if (!Array.isArray(value)) value = [value];
       // collect all keys
       const allKeys = this._collectAllKeys(value);
       // create HTML table

--- a/client/imports/modules/ui_components/index.js
+++ b/client/imports/modules/ui_components/index.js
@@ -167,6 +167,91 @@ UIComponents.prototype = {
       });
     },
 
+    setGridEditorValue({ selector, value }) {
+      // collect all keys
+      const allKeys = new Set();
+      value.forEach(row => {
+        Object.keys(row).forEach(k => allKeys.add(k));
+      });
+      // create HTML table
+      let html = "<table class=\"table table-bordered\">";
+      // table headers
+      html += "<thead><tr>";
+      allKeys.forEach(key => html += `<th>${key}</th>`);
+      html += "</tr></thead>";
+      // data rows
+      html += "<tbody>";
+      value.forEach(row => {
+        html += "<tr>";
+        allKeys.forEach(key => {
+          let val = row[key];
+          if(val !== null && typeof val === 'object') {
+            const valKeys = Object.keys(val);
+            if(valKeys.length === 1 && valKeys[0] === '$date')
+              val = val.$date;
+            else
+              val = JSON.stringify(val);
+          }
+          val = '' + val;
+          if(val.length > 50)
+            html += `<td title="${this.quoteAttr(val)}">${val.substr(0, 47)}...</td>`;
+          else
+            html += `<td>${val}</td>`;
+        });
+        html += "</tr>";
+      });
+      html += "</tbody>";
+      html += "</table>";
+
+      const container = $('#' + selector);
+      container.html(html);
+      const table = container.find('table');
+      table.DataTable({
+        paging: false
+      });
+      const self = this;
+      table.on('dblclick', 'td[title]', function() {
+        self.displayJsonEditorModal(this.getAttribute('title'));
+      });
+    },
+
+    quoteAttr: function(s) {
+      return ('' + s) /* Forces the conversion to string. */
+        .replace(/&/g, '&amp;') /* This MUST be the 1st replacement. */
+        .replace(/'/g, '&apos;') /* The 4 other predefined entities, required. */
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\r\n/g, '&#13;') /* Must be before the next replacement. */
+        .replace(/[\r\n]/g, '&#13;');
+    },
+
+    displayJsonEditorModal(sData) {
+      let modal = $('#json-editor-modal');
+      if(modal.length === 0) {
+        modal = $('<div class="modal fade" id="json-editor-modal" tabindex="-1" role="dialog">' +
+          '  <div class="modal-dialog" role="document">\n' +
+          '    <div class="modal-content">' +
+          '    <div class="modal-header">' +
+          '        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
+          '        <h4 class="modal-title">Cell data</h4>' +
+          '    </div>' +
+          '      <div class="modal-body" id="json-editor-modal-data" style="height: calc(100vh - 100px)"></div>' +
+          '    </div>' +
+          '  </div>' +
+          '</div>');
+        $('body').append(modal);
+
+        this.initializeJSONEditor({selector: 'json-editor-modal-data', options: {
+          mode: 'code',
+          modes: ['code', 'view'],
+          readOnly: true
+        }});
+      }
+      modal.modal();
+      $('#json-editor-modal-data').data('jsoneditor').set(JSON.parse(sData));
+    },
+
     initializeJSONEditor({ selector, options = {}, setDivData = true }) {
       const editorDiv = $(`#${selector}`);
       let jsonEditor = editorDiv.data('jsoneditor');

--- a/client/imports/ui/querying/render.js
+++ b/client/imports/ui/querying/render.js
@@ -375,19 +375,10 @@ QueryRender.prototype = {
 
     const resultTabs = $('#resultTabs');
     resultTabs.on('show.bs.tab', (e) => {
-      const activeTabText = $(e.target).text();
-      const activeTabQueryInfo = activeTabText.substring(0, activeTabText.indexOf(' '));
-
       const query = $($(e.target).attr('href')).data('query');
       if (query) this.renderQuery(query);
 
-      // if active tab is not findOne hide save/delete footer
-      if (activeTabQueryInfo === 'findOne') $('#divBrowseCollectionFooter').show();
-      else if (activeTabQueryInfo === 'find')$('#divBrowseCollectionFindFooter').show();
-      else {
-        $('#divBrowseCollectionFindFooter').hide();
-        $('#divBrowseCollectionFooter').hide();
-      }
+      this.updateQueryResultFooter();
     });
 
     // set onclose
@@ -398,6 +389,20 @@ QueryRender.prototype = {
     });
 
     this.clearQueryIfAdmin();
+  },
+
+  updateQueryResultFooter() {
+    const activeTabText = $('#resultTabs .active').text();
+    const activeTabQueryInfo = activeTabText.substring(0, activeTabText.indexOf(' '));
+
+    const readOnly = this.getWhichResultViewShowing() === 'gridEditor';
+    if (activeTabQueryInfo === 'findOne' && !readOnly) $('#divBrowseCollectionFooter').show();
+    else if (activeTabQueryInfo === 'find' && !readOnly) $('#divBrowseCollectionFindFooter').show();
+    else {
+      // if active tab is not findOne hide save/delete footer
+      $('#divBrowseCollectionFindFooter').hide();
+      $('#divBrowseCollectionFooter').hide();
+    }
   },
 
   switchView() {
@@ -418,6 +423,7 @@ QueryRender.prototype = {
         break;
     }
     this.switchViewTo(whichToShow);
+    this.updateQueryResultFooter();
   },
 
   switchViewTo(whichToShow) {

--- a/client/imports/ui/querying/render.js
+++ b/client/imports/ui/querying/render.js
@@ -421,27 +421,23 @@ QueryRender.prototype = {
   },
 
   switchViewTo(whichToShow) {
-    const showFn = function () {
-      $(this).show('slow');
-    };
-
     const jsonViews = $('div[id^="divActiveJsonEditor"]');
     if (whichToShow === 'jsonEditor') {
-      jsonViews.each(showFn);
+      jsonViews.show('slow');
     } else {
       jsonViews.hide();
     }
 
     const gridViews = $('div[id^="divActiveGridEditor"]');
     if (whichToShow === 'gridEditor') {
-      gridViews.each(showFn);
+      gridViews.show('slow');
     } else {
       gridViews.hide();
     }
 
     const aceViews = $('div[id^="divActiveAceEditor"]');
     if (whichToShow === 'aceEditor') {
-      aceViews.each(showFn);
+      aceViews.show('slow');
     } else {
       aceViews.hide();
     }

--- a/client/imports/views/pages/settings/settings.html
+++ b/client/imports/views/pages/settings/settings.html
@@ -89,6 +89,7 @@
                                             class="chosen-select form-control"
                                             tabindex="-1">
                                         <option>Jsoneditor</option>
+                                        <option>Datatable</option>
                                         <option>Aceeditor</option>
                                     </select>
                                 </div>

--- a/client/stylesheets/globals/custom.import.less
+++ b/client/stylesheets/globals/custom.import.less
@@ -4,3 +4,11 @@
     display: none;
   }
 }
+
+.active-grid-editor {
+  width: 100%;
+  min-height:500px;
+  .dataTables_wrapper {
+    overflow-x: auto;
+  }
+}


### PR DESCRIPTION
## Description
This PR allows to display query result as a grid in addition to JSON editor and ACE editor. Data is displayed in read only mode but it is not very hard to implement inline editing. Actually I made these changes for my own needs and then I decided to share it if someone can find it useful. Personally I rarely use nosqlclient for edit data, but I found that gridview is much more convinient for browsing data. I saw that you started working on rewrite entire codebase to React, so it my be useful at least as idea for 4th release

## Screenshots (if appropriate):
![grid](https://user-images.githubusercontent.com/1955908/50404307-2eb55480-07c8-11e9-85db-d2886f19fa31.png)
![details](https://user-images.githubusercontent.com/1955908/50404308-34129f00-07c8-11e9-8df4-fd7b3704854e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
