### PR TITLE
Add support for docker secrets

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -2,6 +2,40 @@
 
 set -e
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+    echo $var
+    echo "$var"
+    echo $fileVar
+    echo "$fileVar"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'MONGO_URL'
+file_env 'MONGOCLIENT_DEFAULT_CONNECTION_URL'
+file_env 'MONGOCLIENT_USERNAME'
+file_env 'MONGOCLIENT_PASSWORD'
+
+# Defualt connection URL in case no connection URL is provided using the environment variables
+MONGO_URL=${MONGO_URL:-mongodb://127.0.0.1:27017/meteor}
+
 # try to start local MongoDB if no external MONGO_URL was set
 if [[ "${MONGO_URL}" == *"127.0.0.1"* ]]; then
   if hash mongod 2>/dev/null; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GOSU_VERSION 1.10
 
 # default values for Meteor environment variables
 ENV ROOT_URL http://localhost
-ENV MONGO_URL mongodb://127.0.0.1:27017/meteor
+ENV MONGO_URL ''
 ENV PORT 3000
 ENV INSTALL_MONGO true
 ENV MONGOCLIENT_DEFAULT_CONNECTION_URL ''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed the default value for MONGO_URL in the Dockerfile as it is defined in the entrypoint.sh file along with checks for Variable Files.

Added code in entrypoint.sh file to use "VAR_FILE" value, if defined, for different variables

## Related Issue
https://github.com/nosqlclient/nosqlclient/issues/490

## Motivation and Context
Allows the use of Docker Secrets instead of using plain text passwords and sensitive information while creating services in docker-compose

