### PR TITLE
Allow providing Mongo parameters separately

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -28,12 +28,57 @@ file_env() {
 	unset "$fileVar"
 }
 
+file_env 'MONGO_SCHEME'
+file_env 'MONGO_USERNAME'
+file_env 'MONGO_PASSWORD'
+file_env 'MONGO_ADDRESSES'
+file_env 'MONGO_OPT_PARAMS'
+file_env 'MONGO_DATABASE'
+file_env 'MONGO_TLS'
 file_env 'MONGO_URL'
+
+MONGO_SCHEME=${MONGO_SCHEME:-mongodb}
+MONGO_ADDRESSES=${MONGO_ADDRESSES:-127.0.0.1:27017}
+MONGO_DATABASE=${MONGO_DATABASE:-meteor}
+
+URL=
+if [ "${MONGO_URL}" == "" ]
+then
+    URL=${MONGO_SCHEME}://
+    if [ ! -z ${MONGO_USERNAME+x} ]
+    then
+        URL=${URL}${MONGO_USERNAME}
+        if [ ! -z ${MONGO_PASSWORD+x} ]
+    	then
+    	    URL=${URL}:${MONGO_PASSWORD}
+    	fi
+        URL=${URL}@
+    fi
+    URL=${URL}${MONGO_ADDRESSES}/${MONGO_DATABASE}
+	if [ -z ${MONGO_TLS+x} ]
+	then
+    	URL="${URL}?ssl=false"
+	else
+	    URL="${URL}?ssl=${MONGO_TLS}"
+	fi
+    if [ ! -z ${MONGO_OPT_PARAMS+x} ]
+	then  
+	    URL="${URL}&${MONGO_OPT_PARAMS}"
+	fi
+	MONGO_URL=${URL}
+fi
+
 file_env 'MONGOCLIENT_DEFAULT_CONNECTION_URL'
+
+if [ "${MONGOCLIENT_DEFAULT_CONNECTION_URL}" == "" ]
+then
+	MONGOCLIENT_DEFAULT_CONNECTION_URL=$URL
+fi
+
 file_env 'MONGOCLIENT_USERNAME'
 file_env 'MONGOCLIENT_PASSWORD'
 
-# Defualt connection URL in case no connection URL is provided using the environment variables
+# Default connection URL in case no connection URL is provided using the environment variables
 MONGO_URL=${MONGO_URL:-mongodb://127.0.0.1:27017/meteor}
 
 # try to start local MongoDB if no external MONGO_URL was set

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GOSU_VERSION 1.10
 
 # default values for Meteor environment variables
 ENV ROOT_URL http://localhost
-ENV MONGO_URL ''
+
 ENV PORT 3000
 ENV INSTALL_MONGO true
 ENV MONGOCLIENT_DEFAULT_CONNECTION_URL ''


### PR DESCRIPTION
This change introduces, in a backward compatible way, a means to provide
the Mongo connection parameters as separate components.

This allows for easy integration with Kubernetes ConfigMaps and Secrets.

## Description
Introduces ENV variables to Dockerfile:

- MONGO_SCHEME
- MONGO_USERNAME
- MONGO_PASSWORD
- MONGO_ADDRESSES
- MONGO_OPT_PARAMS
- MONGO_DATABASE
- MONGO_TLS

These are ignored if MONGO_URL is set.

## Motivation and Context
To pass different parts of the URL from different Kubernetes resources (ConfigMap/Secret), it is necessary to compose the parts separately into a URL.

## How Has This Been Tested?
I ran the code separately to see if the URL is produced properly.
I built the image using `docker build`.
I testing the image in my local K8s cluster.
Works.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

