### PR TITLE
Modified bundled mongo to support connecting to mongo:latest

### DIFF
--- a/.docker/install-deps.sh
+++ b/.docker/install-deps.sh
@@ -8,6 +8,10 @@ apt-get update -y
 
 apt-get install -y --no-install-recommends curl ca-certificates bzip2 build-essential numactl python git wget bsdtar
 
+curl -O -L http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.0k-1~deb9u1_amd64.deb
+dpkg -i libssl1.1_1.1.0k-1~deb9u1_amd64.deb
+rm libssl1.1_1.1.0k-1~deb9u1_amd64.deb
+
 dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
 
 wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"

--- a/.docker/install-mongo.sh
+++ b/.docker/install-mongo.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
-
+ 
 set -e
 
 if [ "$INSTALL_MONGO" = true ]; then
-  printf "\n[-] Installing MongoDB 3.4.2...\n\n"
-
+  printf "\n[-] Installing MongoDB 4.2...\n\n"
+ 
   cd /tmp
-  curl -O -L https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian81-3.4.2.tgz
-  tar xvzf mongodb-linux-x86_64-debian81-3.4.2.tgz
-  rm mongodb-linux-x86_64-debian81-3.4.2.tgz
+  curl -O -L https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian92-v4.2-latest.tgz
+  mkdir mongodb-linux-x86_64-debian92-v4.2
+  tar xvzf mongodb-linux-x86_64-debian92-v4.2-latest.tgz --strip 1 -C mongodb-linux-x86_64-debian92-v4.2
+  rm mongodb-linux-x86_64-debian92-v4.2-latest.tgz
 
   rm -rf /opt/mongodb
-  mv mongodb-linux-x86_64-debian81-3.4.2 /opt/mongodb
+  mv mongodb-linux-x86_64-debian92-v4.2 /opt/mongodb
 
   ln -sf /opt/mongodb/bin/mongo /usr/bin/mongo
   ln -sf /opt/mongodb/bin/mongod /usr/bin/mongod


### PR DESCRIPTION
## Description
Changes the included mongo utils to v4.2.0, and pulls in libssl and libcrypto 1.1 since this docker image is built on Jessie, and 4.2.0 is built for Stretch.

## Related Issue

https://github.com/nosqlclient/nosqlclient/issues/521


## Motivation and Context
Fixes issue 521

## How Has This Been Tested?
Built new image, deployed container, verified shell connects.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
