### PR TITLE
Update Dockerfile - GID & UID set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-RUN groupadd -r node && useradd -m -g node node
+RUN groupadd -r node -g 1000 && useradd -m -g node -u 1000 node
 
 ENV NODE_VERSION 8.4.0
 ENV GOSU_VERSION 1.10


### PR DESCRIPTION
Set gid and uid in docker image

## Motivation and Context
This is a useful change for provisioning the image in a Kube environment and use the `fsGroup` option.

## How Has This Been Tested?
Tested by building the image manually and launching it

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
