### PR TITLE
Change: Removing $clustertime from query results

### DIFF
--- a/server/imports/core/mongodb/helper.js
+++ b/server/imports/core/mongodb/helper.js
@@ -40,6 +40,19 @@ MongoDBHelper.prototype = {
     }
   },
 
+  removeClusterTimeResult(obj){
+    if (obj.result && (typeof obj.result === 'object')) {
+      if ('$clusterTime' in obj.result) {
+        delete obj.result.$clusterTime;
+      }
+      if(obj.result.result && (typeof obj.result.result === 'object')){
+        if ('$clusterTime' in obj.result.result) {
+          delete obj.result.result.$clusterTime;
+        }
+      }
+    }
+  },
+
   clearConnectionOptionsForLog(connectionOptions) {
     const result = Object.assign({}, connectionOptions);
     delete result.sslCert;
@@ -109,6 +122,7 @@ MongoDBHelper.prototype = {
 
     if (removeCollectionTopology) this.removeCollectionTopologyFromResult(result);
     this.removeConnectionTopologyFromResult(result);
+    this.removeClusterTimeResult(result);
     result = ExtendedJSON.convertBSONtoJSON(result);
     result.executionTime = new Date() - start;
 


### PR DESCRIPTION
Removing clusterTime from queryResults

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
Attempting to solve https://github.com/nosqlclient/nosqlclient/issues/523

## How Has This Been Tested?
- Without this, if we run an updateMany query on any collection in a replicaset, the nosqlClient was crashing. After this patch, it is not crashing. For testing, we can use any free atlas cluster. 

## Screenshots (if appropriate):

## Types of changes
I am not sure, if it can break something. 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
